### PR TITLE
Fixed specified sources

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,6 @@ def submit():
 
 		#checks if the person has been set to 'Other'(if the textbox isn't empty),
 		#if that is the case, change the person propertie to it's value
-		#TODO: make this better validation, as you can now type something, change the person and it's value will stay
 		specific_person = request.form["source_person_other"]
 		if specific_person != "":
 			person = specific_person

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,11 +1,19 @@
 $(document).ready(function(){
+    let source_person_other_value = null;
+    let source_person_other = document.getElementById("source_person_other");
+    let specific_source = document.getElementById("specific_source");
+
     //when the value of the select box changes, change the specific_source#
     $("#source_person").on("change", function(){
         if($(this).val() == "Other"){
-            document.getElementById("specific_source").style.display = "block";
+            specific_source.style.display = "block";
+            source_person_other.value = source_person_other_value;
         }
         else{
-            document.getElementById("specific_source").style.display = "none";
+            specific_source.style.display = "none";
+
+            source_person_other_value = source_person_other.value;
+            source_person_other.value = null;
         }
     })
 })


### PR DESCRIPTION
In the submit view, if you select 'Other', type something in the textbox, and select someone else, it would still get the other specified source. fixed this by removing the value from the textbox, storing it in a variable and set it when you click on the other box again. this makes the value of the textbox empty if it's not selected